### PR TITLE
Revision 1

### DIFF
--- a/controllers/branch.js
+++ b/controllers/branch.js
@@ -1,4 +1,4 @@
-const { exec, execSync } = require('child_process')
+const { exec, execSync, spawnSync } = require('child_process')
 const fs = require('fs').promises
 const fsSync = require('fs')
 
@@ -21,7 +21,8 @@ class BranchController {
       console.log(`Checking repository ${config.repo.name} of ${config.batch_name} started`)
       console.log()
       
-      const output = execSync(`git ls-remote ${config.gitRepo} 'refs/heads/*'`, { encoding: 'utf8' })
+      const output = execSync(`git ls-remote ${config.gitRepo} "refs/heads/*"`, { encoding: 'utf8' })
+
       let branches = output.split('\n').map(line => line.split('\t')[1]).slice(0, -1).map(ref => ref.split('/').splice(-1)[0])
 
       branches = branches.filter(branch => !['master', 'main'].includes(branch)).sort((a, b) => {

--- a/controllers/moss.js
+++ b/controllers/moss.js
@@ -13,7 +13,15 @@ class MossController {
   
       let mossURLs = await Promise.all(results.map(async result => {
         try {
-          let mossOutput = execSync(`./moss -l javascript ./${config.repoBranchOutputDir}/${result.Student1.branch}.js ./${config.repoBranchOutputDir}/${result.Student2.branch}.js`, { encoding: 'utf8' })
+          let args = `-l javascript ./${config.repoBranchOutputDir}/${result.Student1.branch}.js ./${config.repoBranchOutputDir}/${result.Student2.branch}.js`
+          let mossCmd
+
+          if(process.platform === 'win32')
+            mossCmd = `bash -c "./moss ${args}"`
+          else
+            mossCmd = `./moss ${args}`
+
+          let mossOutput = execSync(mossCmd, { encoding: 'utf8' })
           mossOutput = mossOutput.split('\n')
   
           config.debug && console.log(mossOutput)

--- a/controllers/moss.js
+++ b/controllers/moss.js
@@ -16,6 +16,8 @@ class MossController {
           let mossOutput = execSync(`./moss -l javascript ./${config.repoBranchOutputDir}/${result.Student1.branch}.js ./${config.repoBranchOutputDir}/${result.Student2.branch}.js`, { encoding: 'utf8' })
           mossOutput = mossOutput.split('\n')
   
+          config.debug && console.log(mossOutput)
+
           console.log(`Generated case ${counter} of ${resultsCount}`)
           console.log(`URL: ${mossOutput[mossOutput.length - 2]}`)
   

--- a/controllers/moss.js
+++ b/controllers/moss.js
@@ -1,4 +1,6 @@
 // const GithubRepo = require('../models/githubrepo')
+const { execSync } = require('child_process')
+const { writeFileSync } = require('fs')
 
 class MossController {
   static async generateMossResults(results, config){
@@ -25,7 +27,7 @@ class MossController {
         }
       }))
   
-      fsSync.writeFileSync(`results/${config.batch_name}/moss-${config.repo.name}.json`, JSON.stringify(mossURLs, null, 2))
+      writeFileSync(`results/${config.batch_name}/moss-${config.repo.name}.json`, JSON.stringify(mossURLs, null, 2))
       
       success(`MOSS results retrieved and saved in results/moss-${config.repo.name}.json!`)
     })


### PR DESCRIPTION
- Added `debug` option for debugging purposes
- Added support for Windows, fixed errors when executing commands within Windows environment (Note: use `git-bash` also for the workaround, I haven't tested the other shell commands in Windows)
  - Added `process.platform` for OS checking
  - Use double-quotes instead of single-quotes